### PR TITLE
FIX: executablePath() return path even on headful

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -180,10 +180,6 @@ class Chromium {
    * If not running on AWS Lambda nor Google Cloud Functions, `null` is returned instead.
    */
   static get executablePath(): Promise<string> {
-    if (Chromium.headless !== true) {
-      return Promise.resolve(null);
-    }
-
     if (existsSync('/tmp/chromium') === true) {
       for (const file of readdirSync('/tmp')) {
         if (file.startsWith('core.chromium') === true) {


### PR DESCRIPTION
Attempt to fix the issue reported at #6 