### PR TITLE
feat: load chromium binary remote

### DIFF
--- a/source/helper.ts
+++ b/source/helper.ts
@@ -1,0 +1,29 @@
+import { unlink } from "node:fs";
+import { get } from "node:https";
+import { tmpdir } from "node:os";
+import { extract } from 'tar-fs';
+
+export const isValidUrl = (input: string) => {
+    try {
+        return !!new URL(input);
+    } catch (err) {
+        return false;
+    }
+}
+
+export const downloadAndExtract = async (url: string): Promise<string> => new Promise((resolve, reject) => {
+    const destDir = `${tmpdir()}/chromium-pack`
+    const extractObj = extract(destDir)
+    get(url, function (response) {
+        response.pipe(extractObj);
+        extractObj.on('finish', () => {
+            extractObj.end(() => {
+                resolve(destDir);
+            });
+        });
+    }).on('error', (err) => {
+        unlink(destDir, (_) => {
+            reject(err)
+        });
+    });
+})

--- a/source/helper.ts
+++ b/source/helper.ts
@@ -11,19 +11,20 @@ export const isValidUrl = (input: string) => {
     }
 }
 
-export const downloadAndExtract = async (url: string): Promise<string> => new Promise((resolve, reject) => {
-    const destDir = `${tmpdir()}/chromium-pack`
-    const extractObj = extract(destDir)
-    get(url, function (response) {
-        response.pipe(extractObj);
-        extractObj.on('finish', () => {
-            extractObj.end(() => {
-                resolve(destDir);
+export const downloadAndExtract = async (url: string) =>
+    new Promise<string>((resolve, reject) => {
+        const destDir = `${tmpdir()}/chromium-pack`
+        const extractObj = extract(destDir)
+        get(url, (response) => {
+            response.pipe(extractObj);
+            extractObj.on('finish', () => {
+                extractObj.end(() => {
+                    resolve(destDir);
+                });
+            });
+        }).on('error', (err) => {
+            unlink(destDir, (_) => {
+                reject(err)
             });
         });
-    }).on('error', (err) => {
-        unlink(destDir, (_) => {
-            reject(err)
-        });
-    });
-})
+    })

--- a/source/index.ts
+++ b/source/index.ts
@@ -3,6 +3,7 @@ import { IncomingMessage } from 'node:http';
 import LambdaFS from './lambdafs';
 import { join } from 'node:path';
 import { URL } from 'node:url';
+import { downloadAndExtract, isValidUrl } from './helper';
 
 /** Viewport taken from https://github.com/puppeteer/puppeteer/blob/main/docs/api/puppeteer.viewport.md */
 interface Viewport {
@@ -183,14 +184,16 @@ class Chromium {
    * @returns The path to the `chromium` binary
    */
   static async executablePath(input?: string): Promise<string> {
-
     /**
      * If the `chromium` binary already exists in /tmp/chromium, return it.
      */
-    if (existsSync('/tmp/chromium') === true && input === undefined) {
+    if (existsSync('/tmp/chromium') === true) {
       return Promise.resolve('/tmp/chromium');
     }
 
+    if (input && isValidUrl(input)) {
+      return this.executablePath(await downloadAndExtract(input));
+    }
     /**
      * If input is defined, use that as the location of the brotli files,
      * otherwise, the default location is ../bin.


### PR DESCRIPTION
# Why
Work on #18 

# Note
- `executablePath` will accept downloadable url as input (i.e s3 object url). Download file format is `tar`, content is all files in `bin` folder. This tar file can be created by running following code.
```typescript
import { pack } from 'tar-fs';
import { createWriteStream } from 'node:fs';

pack('bin').pipe(createWriteStream('output.tar'));
```
- After downloading, extracting, contents are saved in `/tmp` and `chromium` binary will be reused in future execution.