### PR TITLE
Support for new Chromium 112 `--headless=new` flag

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -46,8 +46,7 @@ interface Viewport {
 
 if (
   process.env.AWS_EXECUTION_ENV !== undefined &&
-  /^AWS_Lambda_nodejs(?:14|16|18)[.]x$/.test(process.env.AWS_EXECUTION_ENV) ===
-    true
+  /^AWS_Lambda_nodejs/.test(process.env.AWS_EXECUTION_ENV) === true
 ) {
   if (process.env.FONTCONFIG_PATH === undefined) {
     process.env.FONTCONFIG_PATH = "/tmp/aws";
@@ -232,9 +231,7 @@ class Chromium {
 
     if (
       process.env.AWS_EXECUTION_ENV !== undefined &&
-      /^AWS_Lambda_nodejs(?:14|16|18)[.]x$/.test(
-        process.env.AWS_EXECUTION_ENV
-      ) === true
+      /^AWS_Lambda_nodejs/.test(process.env.AWS_EXECUTION_ENV) === true
     ) {
       promises.push(LambdaFS.inflate(`${input}/aws.tar.br`));
     }

--- a/source/index.ts
+++ b/source/index.ts
@@ -5,7 +5,7 @@ import {
   mkdirSync,
   symlink,
 } from "node:fs";
-import { IncomingMessage } from "node:http";
+import { https } from "follow-redirects";
 import LambdaFS from "./lambdafs";
 import { join } from "node:path";
 import { URL } from "node:url";
@@ -108,10 +108,7 @@ class Chromium {
           });
         });
       } else {
-        let handler =
-          url.protocol === "http:" ? require("http").get : require("https").get;
-
-        handler(input, (response: IncomingMessage) => {
+        https.get(input, (response) => {
           if (response.statusCode !== 200) {
             return reject(`Unexpected status code: ${response.statusCode}.`);
           }


### PR DESCRIPTION
remove node version check, fixes #75
Change to new headless version
Add ability to disable the graphics stack
Refactor args