### PR TITLE
Update SAM example to v119 and fix readme link

### DIFF
--- a/examples/aws-sam/README.md
+++ b/examples/aws-sam/README.md
@@ -16,4 +16,4 @@
    sam local invoke ExampleFunction
    ```
 
-   This example connects to https://www.example.com and outputs the page's title as the function result. See the source code in [`app.mjs`](app.mjs) for more details.
+   This example connects to https://www.example.com and outputs the page's title as the function result. See the source code in [`app.mjs`](functions/exampleFunction/app.mjs) for more details.

--- a/examples/aws-sam/functions/exampleFunction/package.json
+++ b/examples/aws-sam/functions/exampleFunction/package.json
@@ -2,12 +2,12 @@
   "name": "ExampleFunction",
   "private": true,
   "version": "0.1.0",
-  "description": "AWS Lambda Function that loads Chromium",
+  "description": "AWS Lambda Function that loads Chromium. Refer to https://github.com/Sparticuz/chromium#install for compatible versions.",
   "main": "app.mjs",
   "devDependencies": {
-    "@sparticuz/chromium": "^118.0.0"
+    "@sparticuz/chromium": "^119.0.0"
   },
   "dependencies": {
-    "puppeteer-core": "^21.4.0"
+    "puppeteer-core": "^21.5.1"
   }
 }

--- a/examples/aws-sam/layers/chromium/package.json
+++ b/examples/aws-sam/layers/chromium/package.json
@@ -4,6 +4,6 @@
   "version": "1.0.0",
   "description": "Chromium layer for AWS Lambda",
   "dependencies": {
-    "@sparticuz/chromium": "^118.0.0"
+    "@sparticuz/chromium": "^119.0.0"
   }
 }


### PR DESCRIPTION
A small update to the SAM example which fixes the link in the README which was broken. I also took the chance to quickly update the versioning in the example and link to the install docs so the example doesn't need constant maintenance.

(Thanks for merging #178 👍)