### PR TITLE
Refactor `headless` property typing

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -316,7 +316,7 @@ class Chromium {
    * @returns "shell"
    */
   public static get headless() {
-    return "shell";
+    return "shell" as const;
   }
 
   /**


### PR DESCRIPTION
This small refactor adds a `const` assertion to the `headless` getter in the `Chromium` class. It ensures the return value is treated as a string literal (`"shell"`) rather than a generic string, improving type safety and fix following issue.

![image](https://github.com/user-attachments/assets/480c3f0a-fc28-4d29-b441-71417dc713ba)
