### PR TITLE
Support Vercel Fluid Compute environment

### DIFF
--- a/source/helper.ts
+++ b/source/helper.ts
@@ -44,9 +44,10 @@ export const isValidUrl = (input: string) => {
  * and the nodejs version is less than v20. This is to target AL2 instances
  * AWS_EXECUTION_ENV is for native Lambda instances
  * AWS_LAMBDA_JS_RUNTIME is for netlify instances
+ * VERCEL for Vercel Functions (Node 18 enables an AL2-compatible environment)
  * @returns boolean indicating if the running instance is inside a Lambda container
  */
-export const isRunningInAwsLambda = () => {
+export const isRunningInAwsLambda = (nodeMajorVersion: number) => {
   if (
     process.env["AWS_EXECUTION_ENV"] &&
     process.env["AWS_EXECUTION_ENV"].includes("AWS_Lambda_nodejs") &&
@@ -61,6 +62,8 @@ export const isRunningInAwsLambda = () => {
     !process.env["AWS_LAMBDA_JS_RUNTIME"].includes("22.x")
   ) {
     return true;
+  } else if (process.env["VERCEL"] && nodeMajorVersion == 18) {
+    return true;
   }
   return false;
 };
@@ -71,9 +74,10 @@ export const isRunningInAwsLambda = () => {
  * AWS_EXECUTION_ENV is for native Lambda instances
  * AWS_LAMBDA_JS_RUNTIME is for netlify instances
  * CODEBUILD_BUILD_IMAGE is for CodeBuild instances
+ * VERCEL is for Vercel Functions (Node 20 or later enables an AL2023-compatible environment).
  * @returns boolean indicating if the running instance is inside a Lambda container with nodejs20
  */
-export const isRunningInAwsLambdaNode20 = () => {
+export const isRunningInAwsLambdaNode20 = (nodeMajorVersion: number) => {
   if (
     (process.env["AWS_EXECUTION_ENV"] &&
       process.env["AWS_EXECUTION_ENV"].includes("20.x")) ||
@@ -86,7 +90,8 @@ export const isRunningInAwsLambdaNode20 = () => {
     (process.env["CODEBUILD_BUILD_IMAGE"] &&
       process.env["CODEBUILD_BUILD_IMAGE"].includes("nodejs20")) ||
     (process.env["CODEBUILD_BUILD_IMAGE"] &&
-      process.env["CODEBUILD_BUILD_IMAGE"].includes("nodejs22"))
+      process.env["CODEBUILD_BUILD_IMAGE"].includes("nodejs22")) ||
+    (process.env["VERCEL"] && nodeMajorVersion >= 20)
   ) {
     return true;
   }

--- a/source/index.ts
+++ b/source/index.ts
@@ -50,10 +50,12 @@ interface Viewport {
   hasTouch?: boolean;
 }
 
+const nodeMajorVersion = parseInt(process.versions.node.split(".")[0] ?? '');
+
 // Setup the lambda environment
-if (isRunningInAwsLambda()) {
+if (isRunningInAwsLambda(nodeMajorVersion)) {
   setupLambdaEnvironment("/tmp/al2/lib");
-} else if (isRunningInAwsLambdaNode20()) {
+} else if (isRunningInAwsLambdaNode20(nodeMajorVersion)) {
   setupLambdaEnvironment("/tmp/al2023/lib");
 }
 
@@ -296,11 +298,11 @@ class Chromium {
       // Only inflate graphics stack if needed
       promises.push(LambdaFS.inflate(`${input}/swiftshader.tar.br`));
     }
-    if (isRunningInAwsLambda()) {
+    if (isRunningInAwsLambda(nodeMajorVersion)) {
       // If running in AWS Lambda, extract more required files
       promises.push(LambdaFS.inflate(`${input}/al2.tar.br`));
     }
-    if (isRunningInAwsLambdaNode20()) {
+    if (isRunningInAwsLambdaNode20(nodeMajorVersion)) {
       promises.push(LambdaFS.inflate(`${input}/al2023.tar.br`));
     }
 


### PR DESCRIPTION
We (Vercel) recently released a new function runtime called [Fluid Compute](https://vercel.com/fluid), which is still mostly Lambda compatible, but no longer provide Lambda-specific environment variables that this library assume.

It leads to the following "missing a shared library" error, because `isRunningInAwsLambda` and `isRunningInAwsLambdaNode20` fail to detect Vercel's Lambda-ish environment:

```
/tmp/chromium: error while loading shared libraries: libnss3.so: cannot open shared object file: No such file or directory
```

This PR fixes by determining the AL2/AL2023-compatible environment using the `VERCEL` env var.

