### PR TITLE
fix: handle `error` event for remote font

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -124,6 +124,8 @@ class Chromium {
               return resolve(url.pathname.split("/").pop() as string);
             });
           });
+        }).on("error", (error) => {
+          reject(error)
         });
       }
     });


### PR DESCRIPTION
/cc @Sparticuz. Urgent bug fix

---

When `Chromium.font` is called with an invalid remote host, the AWS Lambda function fails with "Uncaught Exception":

```
2025-04-25T04:27:39.320Z	282a5e59-075c-4852-881e-6d4399a274b8	ERROR	Uncaught Exception
{
	"errorType": "Error",
	"errorMessage": "getaddrinfo ENOTFOUND zqteodgtrgtrqkthczmb.supabase.cox",
	"code": "ENOTFOUND",
	"errno": -3008,
	"syscall": "getaddrinfo",
	"hostname": "zqteodgtrgtrqkthczmb.supabase.cox",
	"stack": [
		"Error: getaddrinfo ENOTFOUND zqteodgtrgtrqkthczmb.supabase.cox",
		"    at GetAddrInfoReqWrap.onlookup [as oncomplete] (node:dns:107:26)"
	]
}

2025-04-25T12:27:39.328+08:00
Unknown application error occurred
Runtime.Unknown
```

This is because the `error` event for `https.get` is not handled in the `font` method.

### Reproduce locally

1. Create a `source/test.mts` file:

   ```typescript
   import Chromium from "./index.js";

   try {
     await Chromium.font(
       "https://zqteodgtrgtrqkthczmb.supabase.cox/storage/v1/object/public/TemplatePDFExport/FONT/Poppins-Regular.ttf"
     );
   } catch (error) {
     console.error("Expect error to be caught", error);
   }
   ```

2. Run `npm run build && node ./build/test.mjs`. The error is not caught by `try...catch`:

   ```
   node:events:485
         throw er; // Unhandled 'error' event
         ^

   Error: getaddrinfo ENOTFOUND zqteodgtrgtrqkthczmb.supabase.cox
       at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:122:26)
   Emitted 'error' event on Writable instance at:
     1 fix: handle `error` event for remote font¬
       at eventHandlers.<computed> (/home/jun/Desktop/github/waiting-for-merge/chromium/node_modules/follow-redirects/index.js:49:24)
       at ClientRequest.emit (node:events:507:28)
       at emitErrorEvent (node:_http_client:104:11)
       at TLSSocket.socketErrorListener (node:_http_client:518:5)
       at TLSSocket.emit (node:events:507:28)
       at emitErrorNT (node:internal/streams/destroy:170:8)
       at emitErrorCloseNT (node:internal/streams/destroy:129:3)
       at process.processTicksAndRejections (node:internal/process/task_queues:90:21) {
     errno: -3008,
     code: 'ENOTFOUND',
     syscall: 'getaddrinfo',
     hostname: 'zqteodgtrgtrqkthczmb.supabase.cox'
   }
   ```

After we handle the `error` event of `https.get`, the error can be caught by `try...catch`:

```
~/Desktop/chromium ❯ npm run build && node build/main.mjs
Expect error to be caught Error: getaddrinfo ENOTFOUND zqteodgtrgtrqkthczmb.supabase.cox
    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:122:26) {
  errno: -3008,
  code: 'ENOTFOUND',
  syscall: 'getaddrinfo',
  hostname: 'zqteodgtrgtrqkthczmb.supabase.cox'
}
```

### References

1. https://nodejs.org/docs/latest/api/https.html#httpsrequestoptions-callback
2. https://stackoverflow.com/a/56874953/7902371
