### PR TITLE
Update to Chromium 142.0.7444.175 to address CVE-2025-13223

### DIFF
--- a/_/ansible/inventory.ini
+++ b/_/ansible/inventory.ini
@@ -16,5 +16,5 @@ arm64_instance=m8g.medium
 ansible_connection=ssh
 ansible_python_interpreter=auto_silent
 ansible_ssh_private_key_file=ansible.pem
-chromium_revision=1509326
+chromium_revision=1522585
 archs=["x64", "arm64"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparticuz/chromium",
-  "version": "141.0.0",
+  "version": "142.0.0",
   "description": "Chromium Binary for Serverless Platforms",
   "keywords": [
     "aws",


### PR DESCRIPTION
Update Chromium revision to 1522585 which corresponds to version 142.0.7444.175. This addresses CVE-2025-13223, an actively exploited Type Confusion vulnerability in V8.

References:
- https://chromereleases.googleblog.com/2025/11/stable-channel-update-for-desktop_17.html
- CVE-2025-13223