### PR TITLE
refactor: replace tar-fs with modern-tar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ define build-zip
 	npm install --fund=false --package-lock=false
 	npm run build
 	mkdir -p nodejs
-	npm install --prefix nodejs/ tar-fs@3.1.2 --bin-links=false --fund=false --omit=optional --omit=dev --package-lock=false --save=false
+	npm install --prefix nodejs/ modern-tar@0.7.6 --bin-links=false --fund=false --omit=optional --omit=dev --package-lock=false --save=false
 	cp -R bin/$(1)/* bin
 	npm pack
 	rm -f bin/chromium.br bin/al2023.tar.br bin/swiftshader.tar.br

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,13 @@
       "version": "149.0.0",
       "license": "MIT",
       "dependencies": {
-        "tar-fs": "^3.1.2"
+        "modern-tar": "^0.7.6"
       },
       "devDependencies": {
         "@sparticuz/eslint-config": "^11.5.0",
         "@tsconfig/node22": "^22.0.5",
         "@tsconfig/strictest": "^2.0.8",
         "@types/node": "^22.19.19",
-        "@types/tar-fs": "^2.0.4",
         "@vitest/coverage-v8": "^4.1.7",
         "clean-modules": "^4.0.0",
         "eslint": "^10.4.0",
@@ -1186,25 +1185,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/tar-fs": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/tar-fs/-/tar-fs-2.0.4.tgz",
-      "integrity": "sha512-ipPec0CjTmVDWE+QKr9cTmIIoTl7dFG/yARCM5MqK8i6CNLIG1P8x4kwDsOQY1ChZOZjH0wO9nvfgBvWl4R3kA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@types/tar-stream": "*"
-      }
-    },
-    "node_modules/@types/tar-stream": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@types/tar-stream/-/tar-stream-2.2.2.tgz",
-      "integrity": "sha512-1AX+Yt3icFuU6kxwmPakaiGrJUwG44MpuiqPg4dSolRFk6jmvs4b3IbUol9wKDLIgU76gevn3EwE8y/DkSJCZQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2095,6 +2075,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
       "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "react-native-b4a": "*"
@@ -2109,6 +2090,7 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "bare-abort-controller": "*"
@@ -2123,6 +2105,7 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.0.tgz",
       "integrity": "sha512-xzqKsCFxAek9aezYhjJuJRXBIaYlg/0OGDTZp+T8eYmYMlm66cs6cYko02drIyjN2CBbi+I6L7YfXyqpqtKRXA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -2147,6 +2130,7 @@
       "version": "3.8.7",
       "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
       "integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "bare": ">=1.14.0"
@@ -2156,6 +2140,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-os": "^3.0.1"
@@ -2165,6 +2150,7 @@
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.12.0.tgz",
       "integrity": "sha512-w28i8lkBgREV3rPXGbgK+BO66q+ZpKqRWrZLiCdmmUlLPrQ45CzkvRhN+7lnv00Gpi2zy5naRxnUFAxCECDm9g==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "streamx": "^2.25.0",
@@ -2191,6 +2177,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
       "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0"
@@ -2697,6 +2684,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -3582,6 +3570,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
       "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
@@ -3608,6 +3597,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -5621,6 +5611,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/modern-tar": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.6.tgz",
+      "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/module-replacements": {
       "version": "3.0.0-beta.7",
       "resolved": "https://registry.npmjs.org/module-replacements/-/module-replacements-3.0.0-beta.7.tgz",
@@ -5728,6 +5727,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -5935,6 +5935,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -6267,6 +6268,7 @@
       "version": "2.25.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
       "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "events-universal": "^1.0.0",
@@ -6409,6 +6411,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
       "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",
@@ -6423,6 +6426,7 @@
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
       "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
@@ -6435,6 +6439,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
       "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "streamx": "^2.12.5"
@@ -6444,6 +6449,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
       "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
@@ -7403,6 +7409,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -52,14 +52,13 @@
     "update": "node ./tools/update-browser-revision.mjs"
   },
   "dependencies": {
-    "tar-fs": "^3.1.2"
+    "modern-tar": "^0.7.6"
   },
   "devDependencies": {
     "@sparticuz/eslint-config": "^11.5.0",
     "@tsconfig/node22": "^22.0.5",
     "@tsconfig/strictest": "^2.0.8",
     "@types/node": "^22.19.19",
-    "@types/tar-fs": "^2.0.4",
     "@vitest/coverage-v8": "^4.1.7",
     "clean-modules": "^4.0.0",
     "eslint": "^10.4.0",

--- a/source/helper.ts
+++ b/source/helper.ts
@@ -1,10 +1,10 @@
+import { unpackTar } from "modern-tar/fs";
 import { createWriteStream, rm } from "node:fs";
 import { access, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
-import { extract } from "tar-fs";
 
 /**
  * Creates a symlink to a file
@@ -142,7 +142,7 @@ export const downloadAndExtract = async (url: string): Promise<string> => {
       Readable.fromWeb(
         response.body as import("node:stream/web").ReadableStream,
       ),
-      extract(destDir),
+      unpackTar(destDir),
     );
   } catch (error) {
     // Clean up partial extraction on failure

--- a/source/lambdafs.ts
+++ b/source/lambdafs.ts
@@ -1,8 +1,8 @@
+import { unpackTar } from "modern-tar/fs";
 import { createReadStream, createWriteStream, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { createBrotliDecompress, createUnzip } from "node:zlib";
-import { extract } from "tar-fs";
 
 const ARCHIVE_EXTENSION_REGEX = /\.(?:t(?:ar(?:\.(?:br|gz))?|br|gz)|br|gz)$/i;
 const TAR_EXTENSION_REGEX = /\.t(?:ar(?:\.(?:br|gz))?|br|gz)$/i;
@@ -55,7 +55,7 @@ export const inflate = (filePath: string): Promise<string> => {
 
     // Setup the appropriate target stream based on file type
     if (isTar) {
-      target = extract(output);
+      target = unpackTar(output);
       target.once("finish", () => {
         resolve(output);
       });

--- a/tests/chromium.test.ts
+++ b/tests/chromium.test.ts
@@ -1,3 +1,4 @@
+import { packTar } from "modern-tar/fs";
 import { execSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
@@ -14,7 +15,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { brotliCompressSync } from "node:zlib";
 import puppeteer, { Browser } from "puppeteer-core";
-import { pack } from "tar-fs";
 import {
   afterAll,
   afterEach,
@@ -351,7 +351,7 @@ describe("Helper", () => {
         tarServer = createServer((req, res) => {
           if (req.url === "/pack.tar") {
             res.writeHead(200, { "Content-Type": "application/x-tar" });
-            pack(fixtureDir).pipe(res);
+            packTar(fixtureDir).pipe(res);
           } else {
             res.writeHead(404);
             res.end();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "outDir": "build",
-    "rootDir": "."
+    "rootDir": ".",
+    "types": ["node"]
   },
   "include": [
     "source",


### PR DESCRIPTION
This migrates `tar-fs` to [`modern-tar`](https://www.npmjs.com/package/modern-tar), dropping the final dependency count from 18 --> 1.

<img width="1512" height="812" alt="image" src="https://github.com/user-attachments/assets/a2340265-5d68-4e94-9520-2a970e773bc9" />

With the latest `puppeteer-core` (I didn't update it in this PR since I'm not sure if it is tied to the release tag of this library), we should also see `tar-fs` fully disappear from the development dependencies of this package as [`@puppeteer/browsers` also uses `modern-tar` now](https://github.com/puppeteer/puppeteer/pull/15028).

On a side note, I added the `node` type to `tsconfig`. Previously, the node types were being imported transitively via `tar-fs`, so now this has to be explicitly done.

Thanks for your time maintaining this package!